### PR TITLE
Add should skip check to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
     name: Skip checks
     runs-on: ubuntu-latest
     outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
       paths_result: ${{ steps.skip_check.outputs.paths_result }}
     steps:
       - name: Check skip workflows
@@ -29,6 +30,7 @@ jobs:
                 "config/**"
 
   build:
+    name: Build Config
     needs: pre_job
     uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
-    if: ${{ !fromJSON(needs.pre_job.outputs.paths_result).build.should_skip }}
+    if: needs.pre_job.outputs.should_skip != 'true' || !fromJSON(needs.pre_job.outputs.paths_result).build.should_skip


### PR DESCRIPTION
Add a condition to check if the global should skip result is true before evaluating stage conditions. 

Snippet from `fkirc/skip-duplicate-actions` docs. 

```yaml
    # If 'skip-duplicate-actions' terminates before the paths checks are performed (for example, when a successful duplicate run has
    # been found) 'paths_result' outputs an empty object ('{}'). This can be easily intercepted in the if condition of a job
    # by checking the result of the "global" 'should_skip' output first.
```