### PR TITLE
Remove should skip global checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,5 @@ jobs:
   standard_checks:
     name: Standard Checks
     needs: pre_job
-    if: !fromJSON(needs.pre_job.outputs.paths_result).standard_checks.should_skip
+    if: ${{ !fromJSON(needs.pre_job.outputs.paths_result).standard_checks.should_skip }}
     uses: ./.github/workflows/ci_standard_checks.yml

--- a/.github/workflows/main_update.yml
+++ b/.github/workflows/main_update.yml
@@ -37,12 +37,12 @@ jobs:
     name: Build Config
     needs: pre_job
     uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
-    if: !fromJSON(needs.pre_job.outputs.paths_result).build.should_skip
+    if: ${{ !fromJSON(needs.pre_job.outputs.paths_result).build.should_skip }}
 
   cache-standard-checks:
     name: Cache standard checks dependencies
     needs: pre_job
-    if: !fromJSON(needs.pre_job.outputs.paths_result).cache_standard_checks.should_skip
+    if: ${{ !fromJSON(needs.pre_job.outputs.paths_result).cache_standard_checks.should_skip }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This check was added as a result of this workflow not skipping the build stage: 

![image](https://user-images.githubusercontent.com/32770960/233782077-83d2b6f8-8c6a-4859-9adc-952110813181.png)

However, adding this was incorrect as the results were unknown rather than should skip. Removing it for now.