### PR TITLE
Move bluetooth buttons to right hand on 2nd layer

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -26,11 +26,11 @@
 
         lower_layer {
             bindings = <
- &kp GRAVE        &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                             &kp F6    &kp F7    &kp F8     &kp F9    &kp F10  &kp PG_UP
-&bt BT_CLR  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4                    &kp C_VOLUME_UP    &trans    &kp UP   &kp LBKT   &kp RBKT  &kp PG_DN
-    &trans      &kp PIPE      &kp BSLH        &trans        &trans        &trans                  &kp C_VOLUME_DOWN  &kp LEFT  &kp DOWN  &kp RIGHT  &kp EQUAL   &kp HOME
-    &trans        &trans        &trans        &trans        &trans        &trans  &trans  &trans             &trans    &trans    &trans     &trans   &kp PLUS    &kp END
-                                              &trans        &trans        &trans  &trans  &trans            &kp DEL    &trans    &trans
+&kp GRAVE    &kp F1    &kp F2  &kp F3  &kp F4  &kp F5                             &kp F6    &kp F7    &kp F8     &kp F9    &kp F10  &kp PG_UP
+   &trans    &trans    &trans  &trans  &trans  &trans                    &kp C_VOLUME_UP    &trans    &kp UP   &kp LBKT   &kp RBKT  &kp PG_DN
+   &trans  &kp PIPE  &kp BSLH  &trans  &trans  &trans                  &kp C_VOLUME_DOWN  &kp LEFT  &kp DOWN  &kp RIGHT  &kp EQUAL   &kp HOME
+   &trans    &trans    &trans  &trans  &trans  &trans  &trans  &trans             &trans    &trans    &trans     &trans   &kp PLUS    &kp END
+                               &trans  &trans  &trans  &trans  &trans            &kp DEL    &trans    &trans
             >;
 
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
@@ -38,10 +38,10 @@
 
         raise_layer {
             bindings = <
-&trans  &trans  &trans  &trans  &trans  &trans                             &trans    &trans    &trans     &trans  &trans  &trans
-&trans  &trans  &trans  &trans  &trans  &trans                    &kp C_VOLUME_UP    &trans    &kp UP     &trans  &trans  &trans
-&trans  &trans  &trans  &trans  &trans  &trans                  &kp C_VOLUME_DOWN  &kp LEFT  &kp DOWN  &kp RIGHT  &trans  &trans
-&trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans             &trans    &trans    &trans     &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans                             &trans    &trans    &trans     &trans        &trans        &trans
+&trans  &trans  &trans  &trans  &trans  &trans                    &kp C_VOLUME_UP    &trans    &kp UP     &trans    &bt BT_CLR  &bt BT_SEL 0
+&trans  &trans  &trans  &trans  &trans  &trans                  &kp C_VOLUME_DOWN  &kp LEFT  &kp DOWN  &kp RIGHT  &bt BT_SEL 1  &bt BT_SEL 2
+&trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans             &trans    &trans    &trans     &trans  &bt BT_SEL 3  &bt BT_SEL 4
                         &trans  &trans  &trans  &trans  &trans             &trans    &trans    &trans
             >;
 


### PR DESCRIPTION
Bluetooth clear caused an issue where it was accidentally pressed when trying to tab when the lower button was pressed. This change moves the Bluetooth buttons to the right hand on the raised layer. 