### PR TITLE
Remove optional sensor bindings

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -20,8 +20,6 @@
  &kp LCTRL   &kp Z   &kp X     &kp C     &kp V   &kp B  &kp LS(LG(S))   &kp C_PP     &kp N   &kp M  &kp COMMA  &kp DOT  &kp FSLH  &kp RSHFT
                             &kp LALT  &kp LGUI   &mo 1     &kp RETURN  &kp SPACE  &kp BSPC   &mo 2   &kp RGUI
             >;
-
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
         };
 
         lower_layer {
@@ -32,8 +30,6 @@
    &trans    &trans    &trans  &trans  &trans  &trans  &trans  &trans             &trans    &trans    &trans     &trans   &kp PLUS    &kp END
                                &trans  &trans  &trans  &trans  &trans            &kp DEL    &trans    &trans
             >;
-
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
         };
 
         raise_layer {
@@ -44,8 +40,6 @@
 &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans             &trans    &trans    &trans     &trans  &bt BT_SEL 3  &bt BT_SEL 4
                         &trans  &trans  &trans  &trans  &trans             &trans    &trans    &trans
             >;
-
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
         };
     };
 };


### PR DESCRIPTION
The ZMK docs suggest that sensor bindings are optional so this or removes them as there are currently no encoders installed. 

Ref: https://zmk.dev/docs/features/keymaps